### PR TITLE
ci: run tests only on push to master and on any PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Restrict the `push` trigger in `tests.yml` to `master`; `pull_request` remains unrestricted (runs on any PR).

## Test plan
- [x] Confirm workflow triggers on push to master
- [x] Confirm workflow triggers on PR open/update to any branch